### PR TITLE
v0.2.3 - VS 1.22 compat + thunder tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Sound Physics Adapted will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.3] - 2026-04-22
+
+### Changed
+- Versioning switched to 3-segment SemVer (was 4-segment) to match Vintage Story's parser. No more `Failed parsing version string` warning at mod load.
+- Distant thunder crack (`nodistance.ogg`) is now noticeably deeper and quieter at long range:
+  - `ThunderCrackPitchMin` default lowered `0.35` → `0.22` (deeper bass tail at >500m)
+  - Far-distance crack volume curve reshaped: ~40-50% quieter beyond 400m vs old curve. Close-range (≤100m) volume unchanged.
+  - 100-400m: now `0.75 → 0.21` (was `0.75 → 0.35`)
+  - 400-1000m: now `0.21 → 0.05` (was `0.35 → 0.10`)
+
 ## [0.2.2.5] - 2026-04-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Sound Physics Adapted will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.2.5] - 2026-04-22
+
+### Changed
+- Updated for Vintage Story 1.22.0 — minimum game version bumped from 1.21.0 to 1.22.0
+- `EnumBlockMaterial.Liquid` references migrated to `EnumBlockMaterial.Water` (renamed upstream in 1.22)
+- Default material config keys renamed `liquid` → `water` (occlusion + reflectivity sections)
+
+### Compatibility
+- Existing user `soundphysicsadapted_materials.json` files using the old `liquid` key continue to work — the loader transparently maps `liquid` onto the new `Water` material when no `water` key is present
+
 ## [0.2.2.3] - 2026-04-03
 
 ### Added

--- a/Config/MaterialSoundConfig.cs
+++ b/Config/MaterialSoundConfig.cs
@@ -186,6 +186,10 @@ namespace soundphysicsadapted
                     string matName = mat.ToString().ToLowerInvariant();
                     if (Occlusion.Materials.TryGetValue(matName, out float val))
                         _materialOcclusionLookup[mat] = val;
+                    // Backward compat: VS 1.22 renamed EnumBlockMaterial.Liquid -> .Water.
+                    // Old user configs use "liquid" key; map it onto Water.
+                    else if (mat == EnumBlockMaterial.Water && Occlusion.Materials.TryGetValue("liquid", out float legacyVal))
+                        _materialOcclusionLookup[mat] = legacyVal;
                 }
             }
 
@@ -218,6 +222,9 @@ namespace soundphysicsadapted
                     string matName = mat.ToString().ToLowerInvariant();
                     if (Reflectivity.Materials.TryGetValue(matName, out float val))
                         _materialReflectivityLookup[mat] = val;
+                    // Backward compat: VS 1.22 renamed EnumBlockMaterial.Liquid -> .Water.
+                    else if (mat == EnumBlockMaterial.Water && Reflectivity.Materials.TryGetValue("liquid", out float legacyVal))
+                        _materialReflectivityLookup[mat] = legacyVal;
                 }
             }
 
@@ -416,7 +423,7 @@ namespace soundphysicsadapted
                         { "leaves", 0.05f },
                         { "stone", 1.0f },
                         { "ore", 1.0f },
-                        { "liquid", 0.8f },      // Water significantly blocks sound (air-water boundary)
+                        { "water", 0.8f },       // Water significantly blocks sound (air-water boundary). VS 1.22: was "liquid".
                         { "snow", 0.25f },
                         { "ice", 0.7f },
                         { "metal", 0.95f },
@@ -531,7 +538,7 @@ namespace soundphysicsadapted
                         { "ice", 1.0f },
                         { "wood", 0.4f },
                         { "soil", 0.3f },
-                        { "liquid", 0.5f },
+                        { "water", 0.5f },       // VS 1.22: was "liquid".
                         { "cloth", 0.1f },
                         { "snow", 0.15f },
                         { "leaves", 0.1f },

--- a/Config/SoundPhysicsConfig.cs
+++ b/Config/SoundPhysicsConfig.cs
@@ -617,7 +617,7 @@ namespace soundphysicsadapted
         /// At close range pitch=1.0 (bright crack), at max distance pitch drops to this value
         /// (deeper, bassier rumble). Simulates high-frequency atmospheric attenuation.
         /// </summary>
-        public float ThunderCrackPitchMin { get; set; } = 0.35f;
+        public float ThunderCrackPitchMin { get; set; } = 0.22f;
 
         /// <summary>
         /// Random pitch variation applied to each thunder event (±this value).

--- a/Core/BlockClassification.cs
+++ b/Core/BlockClassification.cs
@@ -276,13 +276,12 @@ namespace soundphysicsadapted
 
         /// <summary>
         /// Check if a block is a liquid material (water or lava).
-        /// Future-proof helper for VS 1.22: EnumBlockMaterial.Liquid is renamed to .Water.
-        /// When upgrading, only this method needs to change (Liquid → Water).
+        /// VS 1.22: EnumBlockMaterial.Liquid was renamed to .Water.
         /// </summary>
         public static bool IsLiquidMaterial(Block block)
         {
             var mat = block.BlockMaterial;
-            return mat == EnumBlockMaterial.Liquid
+            return mat == EnumBlockMaterial.Water
                 || mat == EnumBlockMaterial.Lava;
         }
 
@@ -333,7 +332,7 @@ namespace soundphysicsadapted
                 EnumBlockMaterial.Glass => 0.1f,
                 EnumBlockMaterial.Leaves => 0.05f,
                 EnumBlockMaterial.Plant => 0.02f,
-                EnumBlockMaterial.Liquid => 0.2f,
+                EnumBlockMaterial.Water => 0.2f,
                 EnumBlockMaterial.Lava => 0.25f,
                 EnumBlockMaterial.Air => 0.0f,
                 _ => 0.5f

--- a/Core/ThunderAudioHandler.cs
+++ b/Core/ThunderAudioHandler.cs
@@ -985,8 +985,10 @@ namespace soundphysicsadapted
         private void FireDelayedCrack(PendingDelayedCrack crack, long gameTimeMs)
         {
             // Crack volume: matches bolt intensity curve but slightly punchier.
-            // Close cracks are full blast, then gentler falloff to 1000m.
-            // Cracks are sharp transients that travel far in real life.
+            // Close cracks are full blast, then steeper falloff for far distances
+            // (~40% quieter at >400m vs original curve, with deeper pitch shift).
+            // Cracks are sharp transients but distant ones lose more energy than
+            // a clean inverse-square — air absorption + ground deflection scrub the high end.
             float crackVol;
             if (crack.Distance <= 30f)
             {
@@ -999,13 +1001,13 @@ namespace soundphysicsadapted
             }
             else if (crack.Distance <= 400f)
             {
-                // 100-400: 0.75 → 0.35 (gradual falloff, still audible)
-                crackVol = 0.75f - ((crack.Distance - 100f) / 300f) * 0.40f;
+                // 100-400: 0.75 → 0.21 (steeper mid falloff, smooth handoff to far tail)
+                crackVol = 0.75f - ((crack.Distance - 100f) / 300f) * 0.54f;
             }
             else if (crack.Distance <= 1000f)
             {
-                // 400-1000: 0.35 → 0.10 (gentle tail, distant but present)
-                crackVol = 0.35f - ((crack.Distance - 400f) / 600f) * 0.25f;
+                // 400-1000: 0.21 → 0.05 (~40-50% quieter than old curve, gentle tail)
+                crackVol = 0.21f - ((crack.Distance - 400f) / 600f) * 0.16f;
             }
             else
             {
@@ -1477,7 +1479,7 @@ namespace soundphysicsadapted
         private float CalculateCrackPitch(float distance)
         {
             var config = SoundPhysicsAdaptedModSystem.Config;
-            float minPitch = config?.ThunderCrackPitchMin ?? 0.35f;
+            float minPitch = config?.ThunderCrackPitchMin ?? 0.22f;
 
             // Steeper pitch curve using t^0.7 (between linear and sqrt).
             // Sqrt curve from 0 blocks — aggressive pitch drop models multi-path

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,12 +6,12 @@
         "Nyarc"
     ],
     "description": "Realistic sound physics for Vintage Story. Raycast occlusion muffles sounds through walls, dynamic reverb reflects off cave geometry, and weather audio responds to your shelter level.",
-    "version": "0.2.2.4",
+    "version": "0.2.2.5",
     "side": "universal",
     "requiredOnServer": false,
     "requiredOnClient": false,
     "dependencies": {
-        "game": "1.21.0"
+        "game": "1.22.0"
     },
     "website": "https://github.com/Myarcer/sound-physics-adapted",
     "contributors": []

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Nyarc"
     ],
     "description": "Realistic sound physics for Vintage Story. Raycast occlusion muffles sounds through walls, dynamic reverb reflects off cave geometry, and weather audio responds to your shelter level.",
-    "version": "0.2.2.5",
+    "version": "0.2.3",
     "side": "universal",
     "requiredOnServer": false,
     "requiredOnClient": false,

--- a/soundphysicsadapted.csproj
+++ b/soundphysicsadapted.csproj
@@ -123,9 +123,13 @@
     <ZipDirectory SourceDirectory=".modpackage" DestinationFile="Releases\soundphysicsadapted_v$(ModVersion).zip" Overwrite="true" />
     <RemoveDir Directories=".modpackage" />
 
-    <!-- Deploy to VS mods folder (1.22 install) -->
-    <Message Text="Deploying to $(AppData)\Vintagestory1.22\Mods\..." Importance="high" />
-    <Copy SourceFiles="Releases\soundphysicsadapted_v$(ModVersion).zip" DestinationFolder="$(AppData)\Vintagestory1.22\Mods\" Condition="Exists('$(AppData)\Vintagestory1.22\Mods\')" />
-    <Copy SourceFiles="Releases\soundphysicsadapted_v$(ModVersion).zip" DestinationFolder="$(AppData)\VintagestoryData\Mods\" Condition="!Exists('$(AppData)\Vintagestory1.22\Mods\') And Exists('$(AppData)\VintagestoryData\Mods\')" />
+    <!-- Deploy to user mods folder. VintagestoryData\Mods\ is the shared user-mods dir
+         (used by both 1.21 and 1.22 installs). Game-bundled Mods inside Vintagestory1.22\
+         is reserved for shipped DLLs (do_not_add_mods_here.txt). -->
+    <PropertyGroup>
+      <DeployDir>$(AppData)\VintagestoryData\Mods\</DeployDir>
+    </PropertyGroup>
+    <Message Text="Deploying to $(DeployDir)" Importance="high" />
+    <Copy SourceFiles="Releases\soundphysicsadapted_v$(ModVersion).zip" DestinationFolder="$(DeployDir)" Condition="$([System.IO.Directory]::Exists('$(DeployDir)'))" />
   </Target>
 </Project>

--- a/soundphysicsadapted.csproj
+++ b/soundphysicsadapted.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>soundphysicsadapted</AssemblyName>
     <RootNamespace>soundphysicsadapted</RootNamespace>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -123,8 +123,9 @@
     <ZipDirectory SourceDirectory=".modpackage" DestinationFile="Releases\soundphysicsadapted_v$(ModVersion).zip" Overwrite="true" />
     <RemoveDir Directories=".modpackage" />
 
-    <!-- Deploy to VS mods folder -->
-    <Message Text="Deploying to $(AppData)\VintagestoryData\Mods\..." Importance="high" />
-    <Copy SourceFiles="Releases\soundphysicsadapted_v$(ModVersion).zip" DestinationFolder="$(AppData)\VintagestoryData\Mods\" />
+    <!-- Deploy to VS mods folder (1.22 install) -->
+    <Message Text="Deploying to $(AppData)\Vintagestory1.22\Mods\..." Importance="high" />
+    <Copy SourceFiles="Releases\soundphysicsadapted_v$(ModVersion).zip" DestinationFolder="$(AppData)\Vintagestory1.22\Mods\" Condition="Exists('$(AppData)\Vintagestory1.22\Mods\')" />
+    <Copy SourceFiles="Releases\soundphysicsadapted_v$(ModVersion).zip" DestinationFolder="$(AppData)\VintagestoryData\Mods\" Condition="!Exists('$(AppData)\Vintagestory1.22\Mods\') And Exists('$(AppData)\VintagestoryData\Mods\')" />
   </Target>
 </Project>


### PR DESCRIPTION
## v0.2.3 - Vintage Story 1.22 release + thunder tuning

### Compatibility
- Built against **Vintage Story 1.22.0** (.NET 10)
- API rename handled: EnumBlockMaterial.Liquid -> Water (user JSON configs with `liquid` key still work via backward-compat fallback)

### Audio
- `ThunderCrackPitchMin` default `0.35` -> `0.22` (deeper bass tail at max range)
- Far-distance crack volume curve ~40-50% quieter beyond 400m (close <=100m unchanged):
  - 100-400m: `0.75 -> 0.21` (was `0.75 -> 0.35`)
  - 400-1000m: `0.21 -> 0.05` (was `0.35 -> 0.10`)

### Versioning / Build
- Version bumped `0.2.2.5` -> `0.2.3` (3-segment SemVer, fixes VS parser warning at mod load)
- `TargetFramework` `net8.0` -> `net10.0`
- Auto-deploy target consolidated to shared `VintagestoryData\Mods\` (works for both 1.21 and 1.22 installs)

### Reference / Dev
- `references/1.22/` populated with 1.22.0 DLLs + depth-1 git clones of vsapi/vssurvivalmod/vsessentialsmod
- `README_DEV.md` updated: install table, build toolchain, known 1.21->1.22 API breaking changes